### PR TITLE
fix outline

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -53,10 +53,6 @@ button {
 button:hover {
   border-color: #646cff;
 }
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
 
 @media (prefers-color-scheme: light) {
   :root {


### PR DESCRIPTION
This pull request removes the outline on the timeslot buttons in the focused state. Before this fix, after a timeslot was selected the button would filled black with a blue outline, which contrasted and seemed unintentional. After this fix, there's no outline in the selected state, so the selected timeslot button just shows as filled color.