### PR TITLE
feat: Guest Permissions & Calendar Visibility Controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Someday is a simple, open-source scheduling tool designed specifically for Gmail
 - **Multiple Event Types**: Create diverse meeting options like "Quick Chat" or "Deep Dive" with unique durations and availability settings.
 - **Team Scheduling**: Add multiple calendars including teammates' calendars (with read access) for collaborative scheduling.
 - **Flexible Scheduling Strategies**: Choose between "Collective" (all team members must be free) or "Round-Robin" (distribute bookings among available team members) scheduling modes.
+- **Guest Permission Controls**: Fine-grained control over what guests can do with booked events (modify, invite others, see attendees) and calendar visibility (public, private, or default).
 - **Dynamic Configuration**: Adjust your timezone, working hours, available days, and monitored calendars globally or per event type directly through the integrated Settings screen.
 - **Owner-Only Access**: Secure access to configuration via the script owner's Google account session.
 - **Simple Booking Process**: Users can select a date and time slot, then fill out a straightforward form with their name, email, phone, and an optional note.
@@ -55,6 +56,14 @@ Someday includes a built-in **Settings** screen for easy configuration.
    **Event Types**:
    - **Custom Meeting Types**: Create unlimited event types (e.g. "15 Min Discovery", "1 Hour Review").
    - **Flexible Durations**: Set specific lengths for each meeting type (up to 24 hours).
+   - **Guest Permissions**: Control what guests can do with booked events:
+     - **Modify Event**: Allow/prevent guests from changing event details, time, or location
+     - **Invite Others**: Allow/prevent guests from adding additional attendees
+     - **See Other Guests**: Allow/prevent guests from viewing the attendee list
+   - **Calendar Visibility**: Choose how events appear in Google Calendar:
+     - **Default**: Uses your calendar's default visibility setting
+     - **Public**: Event details are publicly visible to everyone
+     - **Private**: Shows only as "Busy" without revealing event details
    - **Smart Overrides**: Override global Work Hours, Available Days, Monitored Calendars, and Scheduling Strategy for specific event types.
    - **Per-Event Strategies**: Set different scheduling strategies for different event types (e.g., Round-Robin for sales calls, Collective for team meetings).
    - **Direct Links**: Copy a unique booking URL for any event type to share directly.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "backend",
       "version": "1.0.0",
-      "license": "ISC",
       "dependencies": {
         "@types/google-apps-script": "^1.0.84",
         "typescript": "^5.6.3"

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,12 @@ interface EventType {
   DAYS_IN_ADVANCE?: number;
   CALENDARS?: string[];
   schedulingStrategy?: 'collective' | 'round_robin';
+  // Guest permissions
+  guestsCanModify?: boolean;
+  guestsCanInviteOthers?: boolean;
+  guestsCanSeeOtherGuests?: boolean;
+  // Meeting visibility
+  visibility?: 'default' | 'public' | 'private';
 }
 
 const CONFIG = {
@@ -252,6 +258,19 @@ function bookTimeslot(
         status: "confirmed",
       }
     );
+
+    // Apply guest permissions (defaults: modify=false, invite=false, see=true)
+    event.setGuestsCanModify(eventType.guestsCanModify ?? false);
+    event.setGuestsCanInviteOthers(eventType.guestsCanInviteOthers ?? false);
+    event.setGuestsCanSeeGuests(eventType.guestsCanSeeOtherGuests ?? true);
+
+    // Apply visibility setting
+    if (eventType.visibility === 'public') {
+      event.setVisibility(CalendarApp.Visibility.PUBLIC);
+    } else if (eventType.visibility === 'private') {
+      event.setVisibility(CalendarApp.Visibility.PRIVATE);
+    }
+    // 'default' visibility doesn't require explicit setting
     return `Timeslot booked successfully`;
   } catch (e) {
     const error = e as Error;

--- a/frontend/src/components/ConfigScreen.tsx
+++ b/frontend/src/components/ConfigScreen.tsx
@@ -578,7 +578,7 @@ export function ConfigScreen({ onBack }: { onBack: () => void }) {
                                             <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">minutes</span>
                                         </div>
                                     </div>
-                                    <div className="flex flex-col gap-4">
+                                    <div className="space-y-2">
                                         <div className="flex items-start gap-4">
                                             <Switch
                                                 id={`selectable-${index}`}
@@ -593,7 +593,112 @@ export function ConfigScreen({ onBack }: { onBack: () => void }) {
                                                 <span className="block text-[10px] text-muted-foreground">If disabled, this type can only be booked via direct links</span>
                                             </div>
                                         </div>
-
+                                    </div>
+                                    <div className="space-y-2">
+                                        <div className="space-y-1">
+                                            <Label className="text-sm font-medium">Guest Permissions</Label>
+                                            <p className="text-xs text-muted-foreground">
+                                                Control what guests can do with this event.
+                                            </p>
+                                        </div>
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger asChild>
+                                                <Button variant="outline" className="w-full justify-between font-normal">
+                                                    <span className="truncate">
+                                                        {(() => {
+                                                            const permissions = [];
+                                                            if (et.guestsCanModify) permissions.push('Modify');
+                                                            if (et.guestsCanInviteOthers) permissions.push('Invite');
+                                                            if (et.guestsCanSeeOtherGuests ?? true) permissions.push('See guests');
+                                                            return permissions.length > 0 ? permissions.join(', ') : 'See guests only';
+                                                        })()}
+                                                    </span>
+                                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                </Button>
+                                            </DropdownMenuTrigger>
+                                            <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
+                                                <DropdownMenuCheckboxItem
+                                                    checked={et.guestsCanModify ?? false}
+                                                    onCheckedChange={(checked) => updateEventType(index, { guestsCanModify: checked })}
+                                                    onSelect={(e) => e.preventDefault()}
+                                                >
+                                                    <div className="flex flex-col gap-1">
+                                                        <span>Allow guests to modify event</span>
+                                                        <span className="text-xs text-muted-foreground">Change time, location, details</span>
+                                                    </div>
+                                                </DropdownMenuCheckboxItem>
+                                                <DropdownMenuCheckboxItem
+                                                    checked={et.guestsCanInviteOthers ?? false}
+                                                    onCheckedChange={(checked) => updateEventType(index, { guestsCanInviteOthers: checked })}
+                                                    onSelect={(e) => e.preventDefault()}
+                                                >
+                                                    <div className="flex flex-col gap-1">
+                                                        <span>Allow guests to invite others</span>
+                                                        <span className="text-xs text-muted-foreground">Add additional attendees</span>
+                                                    </div>
+                                                </DropdownMenuCheckboxItem>
+                                                <DropdownMenuCheckboxItem
+                                                    checked={et.guestsCanSeeOtherGuests ?? true}
+                                                    onCheckedChange={(checked) => updateEventType(index, { guestsCanSeeOtherGuests: checked })}
+                                                    onSelect={(e) => e.preventDefault()}
+                                                >
+                                                    <div className="flex flex-col gap-1">
+                                                        <span>Allow guests to see other guests</span>
+                                                        <span className="text-xs text-muted-foreground">View attendee list</span>
+                                                    </div>
+                                                </DropdownMenuCheckboxItem>
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
+                                    </div>
+                                    <div className="space-y-2">
+                                        <div className="space-y-1">
+                                            <Label className="text-sm font-medium">Calendar Visibility</Label>
+                                            <p className="text-xs text-muted-foreground">
+                                                How the event appears in Google Calendar.
+                                            </p>
+                                        </div>
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger asChild>
+                                                <Button variant="outline" className="w-full justify-between font-normal h-auto min-h-10">
+                                                    <div className="flex flex-col items-start gap-0.5 text-left py-1">
+                                                        <span className="font-medium">
+                                                            {et.visibility === 'public' ? 'Public' : et.visibility === 'private' ? 'Private' : 'Default'}
+                                                        </span>
+                                                        <span className="text-[10px] text-muted-foreground font-normal">
+                                                            {et.visibility === 'public'
+                                                                ? 'Event details are publicly visible'
+                                                                : et.visibility === 'private'
+                                                                ? 'Only shows as "Busy" without details'
+                                                                : 'Uses calendar default visibility'}
+                                                        </span>
+                                                    </div>
+                                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                </Button>
+                                            </DropdownMenuTrigger>
+                                            <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
+                                                <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'default' })}>
+                                                    <div className="flex flex-col gap-1">
+                                                        <span>Default</span>
+                                                        <span className="text-xs text-muted-foreground">Uses calendar's default visibility setting</span>
+                                                    </div>
+                                                    {(!et.visibility || et.visibility === 'default') && <Check className="ml-auto h-4 w-4" />}
+                                                </DropdownMenuItem>
+                                                <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'public' })}>
+                                                    <div className="flex flex-col gap-1">
+                                                        <span>Public</span>
+                                                        <span className="text-xs text-muted-foreground">Event details visible to everyone</span>
+                                                    </div>
+                                                    {et.visibility === 'public' && <Check className="ml-auto h-4 w-4" />}
+                                                </DropdownMenuItem>
+                                                <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'private' })}>
+                                                    <div className="flex flex-col gap-1">
+                                                        <span>Private</span>
+                                                        <span className="text-xs text-muted-foreground">Shows as "Busy" without event details</span>
+                                                    </div>
+                                                    {et.visibility === 'private' && <Check className="ml-auto h-4 w-4" />}
+                                                </DropdownMenuItem>
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
                                     </div>
 
 
@@ -832,122 +937,6 @@ export function ConfigScreen({ onBack }: { onBack: () => void }) {
                                                     </DropdownMenu>
                                                 </div>
                                             )}
-                                        </div>
-
-                                        {/* Guest Permissions & Visibility */}
-                                        <div className="pt-6 border-t space-y-4">
-                                            <div className="space-y-1">
-                                                <Label className="text-sm font-semibold">Guest Permissions & Visibility</Label>
-                                                <p className="text-xs text-muted-foreground">
-                                                    Control what guests can do and how the event appears in calendars.
-                                                </p>
-                                            </div>
-
-                                            {/* Guest Permissions */}
-                                            <div className="space-y-3 pl-2">
-                                                <div className="flex items-start gap-4">
-                                                    <Switch
-                                                        id={`guestsCanModify-${index}`}
-                                                        checked={et.guestsCanModify ?? false}
-                                                        onCheckedChange={(checked) => updateEventType(index, { guestsCanModify: checked })}
-                                                        className="mt-1"
-                                                    />
-                                                    <div className="space-y-1">
-                                                        <Label htmlFor={`guestsCanModify-${index}`} className="text-sm font-normal cursor-pointer">
-                                                            Allow guests to modify event
-                                                        </Label>
-                                                        <span className="block text-[10px] text-muted-foreground">
-                                                            Guests can change the event time, location, and other details
-                                                        </span>
-                                                    </div>
-                                                </div>
-
-                                                <div className="flex items-start gap-4">
-                                                    <Switch
-                                                        id={`guestsCanInviteOthers-${index}`}
-                                                        checked={et.guestsCanInviteOthers ?? false}
-                                                        onCheckedChange={(checked) => updateEventType(index, { guestsCanInviteOthers: checked })}
-                                                        className="mt-1"
-                                                    />
-                                                    <div className="space-y-1">
-                                                        <Label htmlFor={`guestsCanInviteOthers-${index}`} className="text-sm font-normal cursor-pointer">
-                                                            Allow guests to invite others
-                                                        </Label>
-                                                        <span className="block text-[10px] text-muted-foreground">
-                                                            Guests can add additional attendees to the event
-                                                        </span>
-                                                    </div>
-                                                </div>
-
-                                                <div className="flex items-start gap-4">
-                                                    <Switch
-                                                        id={`guestsCanSeeOtherGuests-${index}`}
-                                                        checked={et.guestsCanSeeOtherGuests ?? true}
-                                                        onCheckedChange={(checked) => updateEventType(index, { guestsCanSeeOtherGuests: checked })}
-                                                        className="mt-1"
-                                                    />
-                                                    <div className="space-y-1">
-                                                        <Label htmlFor={`guestsCanSeeOtherGuests-${index}`} className="text-sm font-normal cursor-pointer">
-                                                            Allow guests to see other guests
-                                                        </Label>
-                                                        <span className="block text-[10px] text-muted-foreground">
-                                                            Guests can view the list of all attendees
-                                                        </span>
-                                                    </div>
-                                                </div>
-                                            </div>
-
-                                            {/* Visibility Setting */}
-                                            <div className="space-y-2">
-                                                <div className="space-y-1">
-                                                    <Label className="text-sm font-medium">Calendar Visibility</Label>
-                                                    <p className="text-xs text-muted-foreground">
-                                                        Control how the event appears in Google Calendar
-                                                    </p>
-                                                </div>
-                                                <DropdownMenu>
-                                                    <DropdownMenuTrigger asChild>
-                                                        <Button variant="outline" className="w-full justify-between font-normal h-auto min-h-10">
-                                                            <div className="flex flex-col items-start gap-0.5 text-left py-1">
-                                                                <span className="font-medium">
-                                                                    {et.visibility === 'public' ? 'Public' : et.visibility === 'private' ? 'Private' : 'Default'}
-                                                                </span>
-                                                                <span className="text-[10px] text-muted-foreground font-normal">
-                                                                    {et.visibility === 'public'
-                                                                        ? 'Event details are publicly visible'
-                                                                        : et.visibility === 'private'
-                                                                        ? 'Only shows as "Busy" without details'
-                                                                        : 'Uses calendar default visibility'}
-                                                                </span>
-                                                            </div>
-                                                            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                                                        </Button>
-                                                    </DropdownMenuTrigger>
-                                                    <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
-                                                        <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'default' })}>
-                                                            <div className="flex flex-col gap-1">
-                                                                <span>Default</span>
-                                                                <span className="text-xs text-muted-foreground">Uses calendar's default visibility setting</span>
-                                                            </div>
-                                                            {(!et.visibility || et.visibility === 'default') && <Check className="ml-auto h-4 w-4" />}
-                                                        </DropdownMenuItem>
-                                                        <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'public' })}>
-                                                            <div className="flex flex-col gap-1">
-                                                                <span>Public</span>
-                                                                <span className="text-xs text-muted-foreground">Event details visible to everyone</span>
-                                                            </div>
-                                                            {et.visibility === 'public' && <Check className="ml-auto h-4 w-4" />}
-                                                        </DropdownMenuItem>
-                                                        <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'private' })}>
-                                                            <div className="flex flex-col gap-1">
-                                                                <span>Private</span>
-                                                                <span className="text-xs text-muted-foreground">Shows as "Busy" without event details</span>
-                                                            </div>
-                                                            {et.visibility === 'private' && <Check className="ml-auto h-4 w-4" />}
-                                                        </DropdownMenuItem>
-                                                    </DropdownMenuContent>
-                                                </DropdownMenu>
-                                            </div>
                                         </div>
 
                                     </div>

--- a/frontend/src/components/ConfigScreen.tsx
+++ b/frontend/src/components/ConfigScreen.tsx
@@ -834,6 +834,122 @@ export function ConfigScreen({ onBack }: { onBack: () => void }) {
                                             )}
                                         </div>
 
+                                        {/* Guest Permissions & Visibility */}
+                                        <div className="pt-6 border-t space-y-4">
+                                            <div className="space-y-1">
+                                                <Label className="text-sm font-semibold">Guest Permissions & Visibility</Label>
+                                                <p className="text-xs text-muted-foreground">
+                                                    Control what guests can do and how the event appears in calendars.
+                                                </p>
+                                            </div>
+
+                                            {/* Guest Permissions */}
+                                            <div className="space-y-3 pl-2">
+                                                <div className="flex items-start gap-4">
+                                                    <Switch
+                                                        id={`guestsCanModify-${index}`}
+                                                        checked={et.guestsCanModify ?? false}
+                                                        onCheckedChange={(checked) => updateEventType(index, { guestsCanModify: checked })}
+                                                        className="mt-1"
+                                                    />
+                                                    <div className="space-y-1">
+                                                        <Label htmlFor={`guestsCanModify-${index}`} className="text-sm font-normal cursor-pointer">
+                                                            Allow guests to modify event
+                                                        </Label>
+                                                        <span className="block text-[10px] text-muted-foreground">
+                                                            Guests can change the event time, location, and other details
+                                                        </span>
+                                                    </div>
+                                                </div>
+
+                                                <div className="flex items-start gap-4">
+                                                    <Switch
+                                                        id={`guestsCanInviteOthers-${index}`}
+                                                        checked={et.guestsCanInviteOthers ?? false}
+                                                        onCheckedChange={(checked) => updateEventType(index, { guestsCanInviteOthers: checked })}
+                                                        className="mt-1"
+                                                    />
+                                                    <div className="space-y-1">
+                                                        <Label htmlFor={`guestsCanInviteOthers-${index}`} className="text-sm font-normal cursor-pointer">
+                                                            Allow guests to invite others
+                                                        </Label>
+                                                        <span className="block text-[10px] text-muted-foreground">
+                                                            Guests can add additional attendees to the event
+                                                        </span>
+                                                    </div>
+                                                </div>
+
+                                                <div className="flex items-start gap-4">
+                                                    <Switch
+                                                        id={`guestsCanSeeOtherGuests-${index}`}
+                                                        checked={et.guestsCanSeeOtherGuests ?? true}
+                                                        onCheckedChange={(checked) => updateEventType(index, { guestsCanSeeOtherGuests: checked })}
+                                                        className="mt-1"
+                                                    />
+                                                    <div className="space-y-1">
+                                                        <Label htmlFor={`guestsCanSeeOtherGuests-${index}`} className="text-sm font-normal cursor-pointer">
+                                                            Allow guests to see other guests
+                                                        </Label>
+                                                        <span className="block text-[10px] text-muted-foreground">
+                                                            Guests can view the list of all attendees
+                                                        </span>
+                                                    </div>
+                                                </div>
+                                            </div>
+
+                                            {/* Visibility Setting */}
+                                            <div className="space-y-2">
+                                                <div className="space-y-1">
+                                                    <Label className="text-sm font-medium">Calendar Visibility</Label>
+                                                    <p className="text-xs text-muted-foreground">
+                                                        Control how the event appears in Google Calendar
+                                                    </p>
+                                                </div>
+                                                <DropdownMenu>
+                                                    <DropdownMenuTrigger asChild>
+                                                        <Button variant="outline" className="w-full justify-between font-normal h-auto min-h-10">
+                                                            <div className="flex flex-col items-start gap-0.5 text-left py-1">
+                                                                <span className="font-medium">
+                                                                    {et.visibility === 'public' ? 'Public' : et.visibility === 'private' ? 'Private' : 'Default'}
+                                                                </span>
+                                                                <span className="text-[10px] text-muted-foreground font-normal">
+                                                                    {et.visibility === 'public'
+                                                                        ? 'Event details are publicly visible'
+                                                                        : et.visibility === 'private'
+                                                                        ? 'Only shows as "Busy" without details'
+                                                                        : 'Uses calendar default visibility'}
+                                                                </span>
+                                                            </div>
+                                                            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                        </Button>
+                                                    </DropdownMenuTrigger>
+                                                    <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
+                                                        <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'default' })}>
+                                                            <div className="flex flex-col gap-1">
+                                                                <span>Default</span>
+                                                                <span className="text-xs text-muted-foreground">Uses calendar's default visibility setting</span>
+                                                            </div>
+                                                            {(!et.visibility || et.visibility === 'default') && <Check className="ml-auto h-4 w-4" />}
+                                                        </DropdownMenuItem>
+                                                        <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'public' })}>
+                                                            <div className="flex flex-col gap-1">
+                                                                <span>Public</span>
+                                                                <span className="text-xs text-muted-foreground">Event details visible to everyone</span>
+                                                            </div>
+                                                            {et.visibility === 'public' && <Check className="ml-auto h-4 w-4" />}
+                                                        </DropdownMenuItem>
+                                                        <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'private' })}>
+                                                            <div className="flex flex-col gap-1">
+                                                                <span>Private</span>
+                                                                <span className="text-xs text-muted-foreground">Shows as "Busy" without event details</span>
+                                                            </div>
+                                                            {et.visibility === 'private' && <Check className="ml-auto h-4 w-4" />}
+                                                        </DropdownMenuItem>
+                                                    </DropdownMenuContent>
+                                                </DropdownMenu>
+                                            </div>
+                                        </div>
+
                                     </div>
                                 )}
                             </Card>

--- a/frontend/src/components/ConfigScreen.tsx
+++ b/frontend/src/components/ConfigScreen.tsx
@@ -659,19 +659,10 @@ export function ConfigScreen({ onBack }: { onBack: () => void }) {
                                         </div>
                                         <DropdownMenu>
                                             <DropdownMenuTrigger asChild>
-                                                <Button variant="outline" className="w-full justify-between font-normal h-auto min-h-10">
-                                                    <div className="flex flex-col items-start gap-0.5 text-left py-1">
-                                                        <span className="font-medium">
-                                                            {et.visibility === 'public' ? 'Public' : et.visibility === 'private' ? 'Private' : 'Default'}
-                                                        </span>
-                                                        <span className="text-[10px] text-muted-foreground font-normal">
-                                                            {et.visibility === 'public'
-                                                                ? 'Event details are publicly visible'
-                                                                : et.visibility === 'private'
-                                                                ? 'Only shows as "Busy" without details'
-                                                                : 'Uses calendar default visibility'}
-                                                        </span>
-                                                    </div>
+                                                <Button variant="outline" className="w-full justify-between font-normal">
+                                                    <span className="truncate">
+                                                        {et.visibility === 'public' ? 'Public' : et.visibility === 'private' ? 'Private' : 'Default'}
+                                                    </span>
                                                     <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                                                 </Button>
                                             </DropdownMenuTrigger>

--- a/frontend/src/models/EventType.ts
+++ b/frontend/src/models/EventType.ts
@@ -9,6 +9,12 @@ export interface EventType {
     DAYS_IN_ADVANCE?: number;
     CALENDARS?: string[];
     schedulingStrategy?: 'collective' | 'round_robin';
+    // Guest permissions
+    guestsCanModify?: boolean;
+    guestsCanInviteOthers?: boolean;
+    guestsCanSeeOtherGuests?: boolean;
+    // Meeting visibility
+    visibility?: 'default' | 'public' | 'private';
 }
 
 export interface Config {


### PR DESCRIPTION
**Summary**
Adds per-event-type controls for guest permissions and calendar visibility, giving users fine-grained control over event privacy and guest capabilities.

**Features**
🔐 **Guest Permissions (Multi-Select Dropdown)**
- **Modify Event** - Allow guests to change time, location, details (default: false)
- **Invite Others** - Allow guests to add attendees (default: false)
- **See Other Guests** - Allow guests to view attendee list (default: true)

👁️ **Calendar Visibility (Single-Select Dropdown)**
- **Default** - Uses calendar's default visibility
- **Public** - Event details publicly visible
- **Private** - Shows as "Busy" only
