### PR TITLE
Max Bookings Per Event Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Someday is a simple, open-source scheduling tool designed specifically for Gmail
 - **Multiple Event Types**: Create diverse meeting options like "Quick Chat" or "Deep Dive" with unique durations and availability settings.
 - **Team Scheduling**: Add multiple calendars including teammates' calendars (with read access) for collaborative scheduling.
 - **Flexible Scheduling Strategies**: Choose between "Collective" (all team members must be free) or "Round-Robin" (distribute bookings among available team members) scheduling modes.
+- **Guest Permission Controls**: Fine-grained control over what guests can do with booked events (modify, invite others, see attendees) and calendar visibility (public, private, or default).
 - **Dynamic Configuration**: Adjust your timezone, working hours, available days, and monitored calendars globally or per event type directly through the integrated Settings screen.
 - **Owner-Only Access**: Secure access to configuration via the script owner's Google account session.
 - **Simple Booking Process**: Users can select a date and time slot, then fill out a straightforward form with their name, email, phone, and an optional note.
@@ -55,6 +56,14 @@ Someday includes a built-in **Settings** screen for easy configuration.
    **Event Types**:
    - **Custom Meeting Types**: Create unlimited event types (e.g. "15 Min Discovery", "1 Hour Review").
    - **Flexible Durations**: Set specific lengths for each meeting type (up to 24 hours).
+   - **Guest Permissions**: Control what guests can do with booked events:
+     - **Modify Event**: Allow/prevent guests from changing event details, time, or location
+     - **Invite Others**: Allow/prevent guests from adding additional attendees
+     - **See Other Guests**: Allow/prevent guests from viewing the attendee list
+   - **Calendar Visibility**: Choose how events appear in Google Calendar:
+     - **Default**: Uses your calendar's default visibility setting
+     - **Public**: Event details are publicly visible to everyone
+     - **Private**: Shows only as "Busy" without revealing event details
    - **Smart Overrides**: Override global Work Hours, Available Days, Monitored Calendars, and Scheduling Strategy for specific event types.
    - **Per-Event Strategies**: Set different scheduling strategies for different event types (e.g., Round-Robin for sales calls, Collective for team meetings).
    - **Direct Links**: Copy a unique booking URL for any event type to share directly.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Someday is a simple, open-source scheduling tool designed specifically for Gmail
 - **Team Scheduling**: Add multiple calendars including teammates' calendars (with read access) for collaborative scheduling.
 - **Flexible Scheduling Strategies**: Choose between "Collective" (all team members must be free) or "Round-Robin" (distribute bookings among available team members) scheduling modes.
 - **Guest Permission Controls**: Fine-grained control over what guests can do with booked events (modify, invite others, see attendees) and calendar visibility (public, private, or default).
+- **Booking Limits**: Cap how many times a specific event type can be booked per day, week, or month. Maxed-out periods are hidden from the picker and enforced at booking time.
 - **Dynamic Configuration**: Adjust your timezone, working hours, available days, and monitored calendars globally or per event type directly through the integrated Settings screen.
 - **Owner-Only Access**: Secure access to configuration via the script owner's Google account session.
 - **Simple Booking Process**: Users can select a date and time slot, then fill out a straightforward form with their name, email, phone, and an optional note.
@@ -64,6 +65,7 @@ Someday includes a built-in **Settings** screen for easy configuration.
      - **Default**: Uses your calendar's default visibility setting
      - **Public**: Event details are publicly visible to everyone
      - **Private**: Shows only as "Busy" without revealing event details
+   - **Max Bookings**: Limit how many times an event type can be booked within a rolling period. Enter a number and choose **day**, **week**, or **month** (weeks start on Sunday, in your configured time zone). Leave it blank for no limit (the default). The limit applies to the event type as a whole — across all monitored calendars for Round-Robin. Once a period reaches its cap, its slots disappear from the booking page and a final server-side check rejects any attempt to exceed it. Note: only bookings made after this feature is enabled are counted.
    - **Smart Overrides**: Override global Work Hours, Available Days, Monitored Calendars, and Scheduling Strategy for specific event types.
    - **Per-Event Strategies**: Set different scheduling strategies for different event types (e.g., Round-Robin for sales calls, Collective for team meetings).
    - **Direct Links**: Copy a unique booking URL for any event type to share directly.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Someday is a simple, open-source scheduling tool designed specifically for Gmail
 - **Team Scheduling**: Add multiple calendars including teammates' calendars (with read access) for collaborative scheduling.
 - **Flexible Scheduling Strategies**: Choose between "Collective" (all team members must be free) or "Round-Robin" (distribute bookings among available team members) scheduling modes.
 - **Guest Permission Controls**: Fine-grained control over what guests can do with booked events (modify, invite others, see attendees) and calendar visibility (public, private, or default).
-- **Booking Limits**: Cap how many times a specific event type can be booked per day, week, or month. Maxed-out periods are hidden from the picker and enforced at booking time.
+- **Booking Limits**: Cap how many times a specific event type can be booked per day, week, month, quarter, or year. Maxed-out periods are hidden from the picker and enforced at booking time.
 - **Dynamic Configuration**: Adjust your timezone, working hours, available days, and monitored calendars globally or per event type directly through the integrated Settings screen.
 - **Owner-Only Access**: Secure access to configuration via the script owner's Google account session.
 - **Simple Booking Process**: Users can select a date and time slot, then fill out a straightforward form with their name, email, phone, and an optional note.
@@ -65,7 +65,7 @@ Someday includes a built-in **Settings** screen for easy configuration.
      - **Default**: Uses your calendar's default visibility setting
      - **Public**: Event details are publicly visible to everyone
      - **Private**: Shows only as "Busy" without revealing event details
-   - **Max Bookings**: Limit how many times an event type can be booked within a rolling period. Enter a number and choose **day**, **week**, or **month** (weeks start on Sunday, in your configured time zone). Leave it blank for no limit (the default). The limit applies to the event type as a whole — across all monitored calendars for Round-Robin. Once a period reaches its cap, its slots disappear from the booking page and a final server-side check rejects any attempt to exceed it. Note: only bookings made after this feature is enabled are counted.
+   - **Max Bookings**: Limit how many times an event type can be booked within a rolling period. Enter a number and choose **day**, **week**, **month**, **quarter**, or **year** (weeks start on Sunday; quarters and years are calendar-based, all in your configured time zone). Leave it blank for no limit (the default). The limit applies to the event type as a whole — across all monitored calendars for Round-Robin. Once a period reaches its cap, its slots disappear from the booking page and a final server-side check rejects any attempt to exceed it. Note: only bookings made after this feature is enabled are counted.
    - **Smart Overrides**: Override global Work Hours, Available Days, Monitored Calendars, and Scheduling Strategy for specific event types.
    - **Per-Event Strategies**: Set different scheduling strategies for different event types (e.g., Round-Robin for sales calls, Collective for team meetings).
    - **Direct Links**: Copy a unique booking URL for any event type to share directly.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "backend",
       "version": "1.0.0",
-      "license": "ISC",
       "dependencies": {
         "@types/google-apps-script": "^1.0.84",
         "typescript": "^5.6.3"

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,12 @@ interface EventType {
   DAYS_IN_ADVANCE?: number;
   CALENDARS?: string[];
   schedulingStrategy?: 'collective' | 'round_robin';
+  // Guest permissions
+  guestsCanModify?: boolean;
+  guestsCanInviteOthers?: boolean;
+  guestsCanSeeOtherGuests?: boolean;
+  // Meeting visibility
+  visibility?: 'default' | 'public' | 'private';
 }
 
 const CONFIG = {
@@ -252,6 +258,19 @@ function bookTimeslot(
         status: "confirmed",
       }
     );
+
+    // Apply guest permissions (defaults: modify=false, invite=false, see=true)
+    event.setGuestsCanModify(eventType.guestsCanModify ?? false);
+    event.setGuestsCanInviteOthers(eventType.guestsCanInviteOthers ?? false);
+    event.setGuestsCanSeeGuests(eventType.guestsCanSeeOtherGuests ?? true);
+
+    // Apply visibility setting
+    if (eventType.visibility === 'public') {
+      event.setVisibility(CalendarApp.Visibility.PUBLIC);
+    } else if (eventType.visibility === 'private') {
+      event.setVisibility(CalendarApp.Visibility.PRIVATE);
+    }
+    // 'default' visibility doesn't require explicit setting
     return `Timeslot booked successfully`;
   } catch (e) {
     const error = e as Error;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,10 @@ interface EventType {
   DAYS_IN_ADVANCE?: number;
   CALENDARS?: string[];
   schedulingStrategy?: 'collective' | 'round_robin';
+  // Max bookings limit (undefined/0 = no limit). Active only when maxBookings > 0
+  // and maxBookingsPeriod is set. Applies to the whole event type (aggregate).
+  maxBookings?: number;
+  maxBookingsPeriod?: 'day' | 'week' | 'month';
   // Guest permissions
   guestsCanModify?: boolean;
   guestsCanInviteOthers?: boolean;
@@ -118,6 +122,74 @@ function doGet(): GoogleAppsScript.HTML.HtmlOutput {
     .addMetaTag("viewport", "width=device-width, initial-scale=1");
 }
 
+// Returns true when the event type has an active max-bookings limit.
+function hasBookingLimit(eventType: EventType): boolean {
+  return typeof eventType.maxBookings === 'number'
+    && eventType.maxBookings > 0
+    && (eventType.maxBookingsPeriod === 'day'
+      || eventType.maxBookingsPeriod === 'week'
+      || eventType.maxBookingsPeriod === 'month');
+}
+
+// Bucket key for a date within the configured time zone. Bookings sharing a key
+// fall in the same limit period. Weeks start on Sunday.
+function periodKey(date: Date, period: 'day' | 'week' | 'month', tz: string): string {
+  if (period === 'month') {
+    return Utilities.formatDate(date, tz, "yyyy-MM");
+  }
+  if (period === 'day') {
+    return Utilities.formatDate(date, tz, "yyyy-MM-dd");
+  }
+  // week: key by the date of the preceding Sunday (in tz). Do the subtraction as
+  // whole-day calendar arithmetic in UTC — subtracting raw milliseconds off the
+  // original timestamp and re-formatting in tz can land on the wrong day across
+  // a DST transition within the week.
+  const dow = parseInt(Utilities.formatDate(date, tz, "u"), 10) % 7; // u: 1=Mon..7=Sun -> 0=Sun
+  const [y, m, d] = Utilities.formatDate(date, tz, "yyyy-MM-dd").split("-").map(Number);
+  const weekStart = new Date(Date.UTC(y, m - 1, d));
+  weekStart.setUTCDate(weekStart.getUTCDate() - dow);
+  return Utilities.formatDate(weekStart, "UTC", "yyyy-MM-dd");
+}
+
+// Counts existing bookings of an event type per period bucket across the given
+// calendars. Each booking is tagged (private extended property) on exactly one
+// calendar (organizer/target copy), so summing across calendars does not double
+// count and yields the aggregate for the whole event type.
+function countBookingsByPeriod(
+  calendarIds: string[],
+  eventTypeId: string,
+  timeMin: Date,
+  timeMax: Date,
+  period: 'day' | 'week' | 'month',
+  tz: string
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  calendarIds.forEach((calId) => {
+    let pageToken: string | undefined = undefined;
+    do {
+      const resp: any = Calendar.Events!.list(calId, {
+        privateExtendedProperty: 'somedayEventTypeId=' + eventTypeId,
+        timeMin: timeMin.toISOString(),
+        timeMax: timeMax.toISOString(),
+        singleEvents: true,
+        showDeleted: false,
+        maxResults: 2500,
+        pageToken,
+      });
+      (resp.items || []).forEach((ev: any) => {
+        // Don't let cancelled bookings consume limit slots.
+        if (ev.status === 'cancelled') return;
+        const startStr = ev.start && (ev.start.dateTime || ev.start.date);
+        if (!startStr) return;
+        const key = periodKey(new Date(startStr), period, tz);
+        counts[key] = (counts[key] || 0) + 1;
+      });
+      pageToken = resp.nextPageToken;
+    } while (pageToken);
+  });
+  return counts;
+}
+
 function fetchAvailability(eventTypeId?: string): {
   timeslots: string[];
   durationMinutes: number;
@@ -160,6 +232,22 @@ function fetchAvailability(eventTypeId?: string): {
     }));
   });
 
+  // If a max-bookings limit is active, count existing bookings once over the
+  // whole window, bucketed by period, so maxed-out periods can be hidden.
+  // The lower bound reaches ~40 days before now so the *current* period (which
+  // usually started before now for week/month) is fully counted — otherwise it
+  // would be undercounted and slots shown that bookTimeslot then rejects.
+  // Note: the upper bound is only `end` (now + daysInAdvance), not padded, so a
+  // period straddling the end of the display window could be undercounted here
+  // relative to bookTimeslot's ±40d check. That can only happen if bookings
+  // exist beyond the scheduling window; the authoritative check in bookTimeslot
+  // still prevents overbooking, so the worst case is a slot shown then rejected.
+  const limitActive = hasBookingLimit(eventType);
+  const countFrom = new Date(now.getTime() - 40 * 24 * 60 * 60 * 1000);
+  const bookingCounts = limitActive
+    ? countBookingsByPeriod(calendarsToQuery, eventType.id, countFrom, end, eventType.maxBookingsPeriod!, timeZone)
+    : {};
+
   //get all timeslots between now and end date
   const timeslots = [];
   const strategy = eventType.schedulingStrategy ?? CONFIG.schedulingStrategy ?? 'collective';
@@ -186,9 +274,15 @@ function fetchAvailability(eventTypeId?: string): {
       ? freeCalendarsCount > 0
       : freeCalendarsCount === calendarsToQuery.length;
 
-    if (isAvailable) {
-      timeslots.push(start.toISOString());
+    if (!isAvailable) continue;
+
+    // Skip slots whose period has already reached the booking limit.
+    if (limitActive) {
+      const key = periodKey(start, eventType.maxBookingsPeriod!, timeZone);
+      if ((bookingCounts[key] || 0) >= eventType.maxBookings!) continue;
     }
+
+    timeslots.push(start.toISOString());
   }
   return { timeslots, durationMinutes };
 }
@@ -204,13 +298,51 @@ function bookTimeslot(
   const eventType = CONFIG.EVENT_TYPES.find((et: EventType) => et.id === eventTypeId) || CONFIG.EVENT_TYPES[0];
   const durationMinutes = eventType.duration;
   const calendarsToUse = eventType.CALENDARS ?? CONFIG.CALENDARS;
-  const calendarId = calendarsToUse[0];
   const startTime = new Date(timeslot);
   if (isNaN(startTime.getTime())) {
     throw new Error("Invalid start time");
   }
   const endTime = new Date(startTime.getTime());
   endTime.setUTCMinutes(startTime.getUTCMinutes() + durationMinutes);
+
+  // Authoritative max-bookings check. Hold a script lock across the count-check
+  // AND the event creation below so two concurrent bookings for the last slot in
+  // a period can't both pass the check and both create events. Count over a
+  // window that comfortably covers the slot's period, then look up the slot's
+  // own period bucket.
+  let bookingLock: GoogleAppsScript.Lock.Lock | null = null;
+  if (hasBookingLimit(eventType)) {
+    bookingLock = LockService.getScriptLock();
+    try {
+      bookingLock.waitLock(15000);
+    } catch (e) {
+      throw new Error("Server is busy, please try again");
+    }
+    // Release the lock on any failure within the pre-check itself (including the
+    // count query throwing), then rethrow unchanged. On the happy path the lock
+    // stays held through event creation, where the finally block releases it.
+    try {
+      const tz = CONFIG.TIME_ZONE;
+      const period = eventType.maxBookingsPeriod!;
+      const padMs = 40 * 24 * 60 * 60 * 1000;
+      const counts = countBookingsByPeriod(
+        calendarsToUse,
+        eventType.id,
+        new Date(startTime.getTime() - padMs),
+        new Date(startTime.getTime() + padMs),
+        period,
+        tz
+      );
+      const key = periodKey(startTime, period, tz);
+      if ((counts[key] || 0) >= eventType.maxBookings!) {
+        throw new Error("Booking limit reached for this period");
+      }
+    } catch (e) {
+      bookingLock.releaseLock();
+      bookingLock = null;
+      throw e;
+    }
+  }
 
   try {
     const possibleEvents = Calendar.Freebusy!.query({
@@ -247,33 +379,47 @@ function bookTimeslot(
       guestsToInvite = [...guestsToInvite, ...teamGuests];
     }
 
-    const event = CalendarApp.getCalendarById(targetCalendarId).createEvent(
-      `Appointment with ${name}`,
-      startTime,
-      endTime,
-      {
-        description: `Phone: ${phone}\nNote: ${note}`,
-        guests: guestsToInvite.join(','),
-        sendInvites: true,
-        status: "confirmed",
-      }
-    );
-
-    // Apply guest permissions (defaults: modify=false, invite=false, see=true)
-    event.setGuestsCanModify(eventType.guestsCanModify ?? false);
-    event.setGuestsCanInviteOthers(eventType.guestsCanInviteOthers ?? false);
-    event.setGuestsCanSeeGuests(eventType.guestsCanSeeOtherGuests ?? true);
-
-    // Apply visibility setting
+    // Create the event atomically with its event-type tag, using the advanced
+    // Calendar API (Events.insert) rather than CalendarApp.createEvent followed
+    // by a separate patch. A two-step create-then-tag can fail *after* the event
+    // exists and invites have been sent, which would both report a real booking
+    // as failed AND leave it untagged — invisible to countBookingsByPeriod, so
+    // the limit would permanently under-count and a retry would duplicate the
+    // booking. One insert makes it a single atomic operation and also gives us
+    // the real event id directly (no fragile iCalUID suffix stripping).
+    //
+    // somedayEventTypeId is a *private* extended property (countBookingsByPeriod
+    // filters on privateExtendedProperty). Private properties live only on the
+    // organizer/target copy and don't propagate to guest calendars, which keeps
+    // that function's single-copy assumption valid so summing across calendars
+    // never double counts. sendUpdates: 'all' preserves the prior sendInvites.
+    const resource: any = {
+      summary: `Appointment with ${name}`,
+      description: `Phone: ${phone}\nNote: ${note}`,
+      start: { dateTime: startTime.toISOString() },
+      end: { dateTime: endTime.toISOString() },
+      status: "confirmed",
+      attendees: guestsToInvite.map((guestEmail: string) => ({ email: guestEmail })),
+      // Guest permissions (defaults: modify=false, invite=false, see=true)
+      guestsCanModify: eventType.guestsCanModify ?? false,
+      guestsCanInviteOthers: eventType.guestsCanInviteOthers ?? false,
+      guestsCanSeeOtherGuests: eventType.guestsCanSeeOtherGuests ?? true,
+      extendedProperties: { private: { somedayEventTypeId: eventType.id } },
+    };
+    // Visibility ('default' needs no explicit value)
     if (eventType.visibility === 'public') {
-      event.setVisibility(CalendarApp.Visibility.PUBLIC);
+      resource.visibility = 'public';
     } else if (eventType.visibility === 'private') {
-      event.setVisibility(CalendarApp.Visibility.PRIVATE);
+      resource.visibility = 'private';
     }
-    // 'default' visibility doesn't require explicit setting
+
+    Calendar.Events!.insert(resource, targetCalendarId, { sendUpdates: 'all' });
+
     return `Timeslot booked successfully`;
   } catch (e) {
     const error = e as Error;
     throw new Error(`Failed to create event: ${error.message}`);
+  } finally {
+    if (bookingLock) bookingLock.releaseLock();
   }
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,5 +1,7 @@
 const props = PropertiesService.getScriptProperties();
 
+type BookingPeriod = 'day' | 'week' | 'month' | 'quarter' | 'year';
+
 interface EventType {
   id: string;
   name: string;
@@ -14,7 +16,7 @@ interface EventType {
   // Max bookings limit (undefined/0 = no limit). Active only when maxBookings > 0
   // and maxBookingsPeriod is set. Applies to the whole event type (aggregate).
   maxBookings?: number;
-  maxBookingsPeriod?: 'day' | 'week' | 'month';
+  maxBookingsPeriod?: BookingPeriod;
   // Guest permissions
   guestsCanModify?: boolean;
   guestsCanInviteOthers?: boolean;
@@ -122,18 +124,40 @@ function doGet(): GoogleAppsScript.HTML.HtmlOutput {
     .addMetaTag("viewport", "width=device-width, initial-scale=1");
 }
 
+const VALID_BOOKING_PERIODS: BookingPeriod[] = ['day', 'week', 'month', 'quarter', 'year'];
+
 // Returns true when the event type has an active max-bookings limit.
 function hasBookingLimit(eventType: EventType): boolean {
   return typeof eventType.maxBookings === 'number'
     && eventType.maxBookings > 0
-    && (eventType.maxBookingsPeriod === 'day'
-      || eventType.maxBookingsPeriod === 'week'
-      || eventType.maxBookingsPeriod === 'month');
+    && VALID_BOOKING_PERIODS.indexOf(eventType.maxBookingsPeriod as BookingPeriod) >= 0;
+}
+
+// How far the count window must reach back from "now" to cover the *start* of
+// the current period (which for longer periods began well before now), sized
+// generously per period so the current bucket is never undercounted.
+function periodPaddingMs(period: BookingPeriod): number {
+  const DAY = 24 * 60 * 60 * 1000;
+  switch (period) {
+    case 'day': return 2 * DAY;
+    case 'week': return 9 * DAY;
+    case 'month': return 40 * DAY;
+    case 'quarter': return 100 * DAY;
+    case 'year': return 375 * DAY;
+  }
 }
 
 // Bucket key for a date within the configured time zone. Bookings sharing a key
-// fall in the same limit period. Weeks start on Sunday.
-function periodKey(date: Date, period: 'day' | 'week' | 'month', tz: string): string {
+// fall in the same limit period. Weeks start on Sunday; quarters and years are
+// calendar-based (Q1 = Jan–Mar, etc.).
+function periodKey(date: Date, period: BookingPeriod, tz: string): string {
+  if (period === 'year') {
+    return Utilities.formatDate(date, tz, "yyyy");
+  }
+  if (period === 'quarter') {
+    const [yy, mm] = Utilities.formatDate(date, tz, "yyyy-MM").split("-").map(Number);
+    return yy + "-Q" + (Math.floor((mm - 1) / 3) + 1);
+  }
   if (period === 'month') {
     return Utilities.formatDate(date, tz, "yyyy-MM");
   }
@@ -160,7 +184,7 @@ function countBookingsByPeriod(
   eventTypeId: string,
   timeMin: Date,
   timeMax: Date,
-  period: 'day' | 'week' | 'month',
+  period: BookingPeriod,
   tz: string
 ): Record<string, number> {
   const counts: Record<string, number> = {};
@@ -234,16 +258,19 @@ function fetchAvailability(eventTypeId?: string): {
 
   // If a max-bookings limit is active, count existing bookings once over the
   // whole window, bucketed by period, so maxed-out periods can be hidden.
-  // The lower bound reaches ~40 days before now so the *current* period (which
-  // usually started before now for week/month) is fully counted — otherwise it
-  // would be undercounted and slots shown that bookTimeslot then rejects.
+  // The lower bound reaches back far enough (per period) to fully cover the
+  // *current* period, which usually started before now (and much earlier for
+  // quarter/year) — otherwise it would be undercounted and slots shown that
+  // bookTimeslot then rejects.
   // Note: the upper bound is only `end` (now + daysInAdvance), not padded, so a
   // period straddling the end of the display window could be undercounted here
-  // relative to bookTimeslot's ±40d check. That can only happen if bookings
+  // relative to bookTimeslot's padded check. That can only happen if bookings
   // exist beyond the scheduling window; the authoritative check in bookTimeslot
   // still prevents overbooking, so the worst case is a slot shown then rejected.
   const limitActive = hasBookingLimit(eventType);
-  const countFrom = new Date(now.getTime() - 40 * 24 * 60 * 60 * 1000);
+  const countFrom = limitActive
+    ? new Date(now.getTime() - periodPaddingMs(eventType.maxBookingsPeriod!))
+    : now;
   const bookingCounts = limitActive
     ? countBookingsByPeriod(calendarsToQuery, eventType.id, countFrom, end, eventType.maxBookingsPeriod!, timeZone)
     : {};
@@ -324,7 +351,7 @@ function bookTimeslot(
     try {
       const tz = CONFIG.TIME_ZONE;
       const period = eventType.maxBookingsPeriod!;
-      const padMs = 40 * 24 * 60 * 60 * 1000;
+      const padMs = periodPaddingMs(period);
       const counts = countBookingsByPeriod(
         calendarsToUse,
         eventType.id,

--- a/frontend/src/components/ConfigScreen.tsx
+++ b/frontend/src/components/ConfigScreen.tsx
@@ -578,7 +578,7 @@ export function ConfigScreen({ onBack }: { onBack: () => void }) {
                                             <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">minutes</span>
                                         </div>
                                     </div>
-                                    <div className="flex flex-col gap-4">
+                                    <div className="space-y-2">
                                         <div className="flex items-start gap-4">
                                             <Switch
                                                 id={`selectable-${index}`}
@@ -593,7 +593,112 @@ export function ConfigScreen({ onBack }: { onBack: () => void }) {
                                                 <span className="block text-[10px] text-muted-foreground">If disabled, this type can only be booked via direct links</span>
                                             </div>
                                         </div>
-
+                                    </div>
+                                    <div className="space-y-2">
+                                        <div className="space-y-1">
+                                            <Label className="text-sm font-medium">Guest Permissions</Label>
+                                            <p className="text-xs text-muted-foreground">
+                                                Control what guests can do with this event.
+                                            </p>
+                                        </div>
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger asChild>
+                                                <Button variant="outline" className="w-full justify-between font-normal">
+                                                    <span className="truncate">
+                                                        {(() => {
+                                                            const permissions = [];
+                                                            if (et.guestsCanModify) permissions.push('Modify');
+                                                            if (et.guestsCanInviteOthers) permissions.push('Invite');
+                                                            if (et.guestsCanSeeOtherGuests ?? true) permissions.push('See guests');
+                                                            return permissions.length > 0 ? permissions.join(', ') : 'See guests only';
+                                                        })()}
+                                                    </span>
+                                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                </Button>
+                                            </DropdownMenuTrigger>
+                                            <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
+                                                <DropdownMenuCheckboxItem
+                                                    checked={et.guestsCanModify ?? false}
+                                                    onCheckedChange={(checked) => updateEventType(index, { guestsCanModify: checked })}
+                                                    onSelect={(e) => e.preventDefault()}
+                                                >
+                                                    <div className="flex flex-col gap-1">
+                                                        <span>Allow guests to modify event</span>
+                                                        <span className="text-xs text-muted-foreground">Change time, location, details</span>
+                                                    </div>
+                                                </DropdownMenuCheckboxItem>
+                                                <DropdownMenuCheckboxItem
+                                                    checked={et.guestsCanInviteOthers ?? false}
+                                                    onCheckedChange={(checked) => updateEventType(index, { guestsCanInviteOthers: checked })}
+                                                    onSelect={(e) => e.preventDefault()}
+                                                >
+                                                    <div className="flex flex-col gap-1">
+                                                        <span>Allow guests to invite others</span>
+                                                        <span className="text-xs text-muted-foreground">Add additional attendees</span>
+                                                    </div>
+                                                </DropdownMenuCheckboxItem>
+                                                <DropdownMenuCheckboxItem
+                                                    checked={et.guestsCanSeeOtherGuests ?? true}
+                                                    onCheckedChange={(checked) => updateEventType(index, { guestsCanSeeOtherGuests: checked })}
+                                                    onSelect={(e) => e.preventDefault()}
+                                                >
+                                                    <div className="flex flex-col gap-1">
+                                                        <span>Allow guests to see other guests</span>
+                                                        <span className="text-xs text-muted-foreground">View attendee list</span>
+                                                    </div>
+                                                </DropdownMenuCheckboxItem>
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
+                                    </div>
+                                    <div className="space-y-2">
+                                        <div className="space-y-1">
+                                            <Label className="text-sm font-medium">Calendar Visibility</Label>
+                                            <p className="text-xs text-muted-foreground">
+                                                How the event appears in Google Calendar.
+                                            </p>
+                                        </div>
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger asChild>
+                                                <Button variant="outline" className="w-full justify-between font-normal h-auto min-h-10">
+                                                    <div className="flex flex-col items-start gap-0.5 text-left py-1">
+                                                        <span className="font-medium">
+                                                            {et.visibility === 'public' ? 'Public' : et.visibility === 'private' ? 'Private' : 'Default'}
+                                                        </span>
+                                                        <span className="text-[10px] text-muted-foreground font-normal">
+                                                            {et.visibility === 'public'
+                                                                ? 'Event details are publicly visible'
+                                                                : et.visibility === 'private'
+                                                                ? 'Only shows as "Busy" without details'
+                                                                : 'Uses calendar default visibility'}
+                                                        </span>
+                                                    </div>
+                                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                </Button>
+                                            </DropdownMenuTrigger>
+                                            <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
+                                                <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'default' })}>
+                                                    <div className="flex flex-col gap-1">
+                                                        <span>Default</span>
+                                                        <span className="text-xs text-muted-foreground">Uses calendar's default visibility setting</span>
+                                                    </div>
+                                                    {(!et.visibility || et.visibility === 'default') && <Check className="ml-auto h-4 w-4" />}
+                                                </DropdownMenuItem>
+                                                <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'public' })}>
+                                                    <div className="flex flex-col gap-1">
+                                                        <span>Public</span>
+                                                        <span className="text-xs text-muted-foreground">Event details visible to everyone</span>
+                                                    </div>
+                                                    {et.visibility === 'public' && <Check className="ml-auto h-4 w-4" />}
+                                                </DropdownMenuItem>
+                                                <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'private' })}>
+                                                    <div className="flex flex-col gap-1">
+                                                        <span>Private</span>
+                                                        <span className="text-xs text-muted-foreground">Shows as "Busy" without event details</span>
+                                                    </div>
+                                                    {et.visibility === 'private' && <Check className="ml-auto h-4 w-4" />}
+                                                </DropdownMenuItem>
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
                                     </div>
 
 
@@ -832,122 +937,6 @@ export function ConfigScreen({ onBack }: { onBack: () => void }) {
                                                     </DropdownMenu>
                                                 </div>
                                             )}
-                                        </div>
-
-                                        {/* Guest Permissions & Visibility */}
-                                        <div className="pt-6 border-t space-y-4">
-                                            <div className="space-y-1">
-                                                <Label className="text-sm font-semibold">Guest Permissions & Visibility</Label>
-                                                <p className="text-xs text-muted-foreground">
-                                                    Control what guests can do and how the event appears in calendars.
-                                                </p>
-                                            </div>
-
-                                            {/* Guest Permissions */}
-                                            <div className="space-y-3 pl-2">
-                                                <div className="flex items-start gap-4">
-                                                    <Switch
-                                                        id={`guestsCanModify-${index}`}
-                                                        checked={et.guestsCanModify ?? false}
-                                                        onCheckedChange={(checked) => updateEventType(index, { guestsCanModify: checked })}
-                                                        className="mt-1"
-                                                    />
-                                                    <div className="space-y-1">
-                                                        <Label htmlFor={`guestsCanModify-${index}`} className="text-sm font-normal cursor-pointer">
-                                                            Allow guests to modify event
-                                                        </Label>
-                                                        <span className="block text-[10px] text-muted-foreground">
-                                                            Guests can change the event time, location, and other details
-                                                        </span>
-                                                    </div>
-                                                </div>
-
-                                                <div className="flex items-start gap-4">
-                                                    <Switch
-                                                        id={`guestsCanInviteOthers-${index}`}
-                                                        checked={et.guestsCanInviteOthers ?? false}
-                                                        onCheckedChange={(checked) => updateEventType(index, { guestsCanInviteOthers: checked })}
-                                                        className="mt-1"
-                                                    />
-                                                    <div className="space-y-1">
-                                                        <Label htmlFor={`guestsCanInviteOthers-${index}`} className="text-sm font-normal cursor-pointer">
-                                                            Allow guests to invite others
-                                                        </Label>
-                                                        <span className="block text-[10px] text-muted-foreground">
-                                                            Guests can add additional attendees to the event
-                                                        </span>
-                                                    </div>
-                                                </div>
-
-                                                <div className="flex items-start gap-4">
-                                                    <Switch
-                                                        id={`guestsCanSeeOtherGuests-${index}`}
-                                                        checked={et.guestsCanSeeOtherGuests ?? true}
-                                                        onCheckedChange={(checked) => updateEventType(index, { guestsCanSeeOtherGuests: checked })}
-                                                        className="mt-1"
-                                                    />
-                                                    <div className="space-y-1">
-                                                        <Label htmlFor={`guestsCanSeeOtherGuests-${index}`} className="text-sm font-normal cursor-pointer">
-                                                            Allow guests to see other guests
-                                                        </Label>
-                                                        <span className="block text-[10px] text-muted-foreground">
-                                                            Guests can view the list of all attendees
-                                                        </span>
-                                                    </div>
-                                                </div>
-                                            </div>
-
-                                            {/* Visibility Setting */}
-                                            <div className="space-y-2">
-                                                <div className="space-y-1">
-                                                    <Label className="text-sm font-medium">Calendar Visibility</Label>
-                                                    <p className="text-xs text-muted-foreground">
-                                                        Control how the event appears in Google Calendar
-                                                    </p>
-                                                </div>
-                                                <DropdownMenu>
-                                                    <DropdownMenuTrigger asChild>
-                                                        <Button variant="outline" className="w-full justify-between font-normal h-auto min-h-10">
-                                                            <div className="flex flex-col items-start gap-0.5 text-left py-1">
-                                                                <span className="font-medium">
-                                                                    {et.visibility === 'public' ? 'Public' : et.visibility === 'private' ? 'Private' : 'Default'}
-                                                                </span>
-                                                                <span className="text-[10px] text-muted-foreground font-normal">
-                                                                    {et.visibility === 'public'
-                                                                        ? 'Event details are publicly visible'
-                                                                        : et.visibility === 'private'
-                                                                        ? 'Only shows as "Busy" without details'
-                                                                        : 'Uses calendar default visibility'}
-                                                                </span>
-                                                            </div>
-                                                            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                                                        </Button>
-                                                    </DropdownMenuTrigger>
-                                                    <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
-                                                        <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'default' })}>
-                                                            <div className="flex flex-col gap-1">
-                                                                <span>Default</span>
-                                                                <span className="text-xs text-muted-foreground">Uses calendar's default visibility setting</span>
-                                                            </div>
-                                                            {(!et.visibility || et.visibility === 'default') && <Check className="ml-auto h-4 w-4" />}
-                                                        </DropdownMenuItem>
-                                                        <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'public' })}>
-                                                            <div className="flex flex-col gap-1">
-                                                                <span>Public</span>
-                                                                <span className="text-xs text-muted-foreground">Event details visible to everyone</span>
-                                                            </div>
-                                                            {et.visibility === 'public' && <Check className="ml-auto h-4 w-4" />}
-                                                        </DropdownMenuItem>
-                                                        <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'private' })}>
-                                                            <div className="flex flex-col gap-1">
-                                                                <span>Private</span>
-                                                                <span className="text-xs text-muted-foreground">Shows as "Busy" without event details</span>
-                                                            </div>
-                                                            {et.visibility === 'private' && <Check className="ml-auto h-4 w-4" />}
-                                                        </DropdownMenuItem>
-                                                    </DropdownMenuContent>
-                                                </DropdownMenu>
-                                            </div>
                                         </div>
 
                                     </div>

--- a/frontend/src/components/ConfigScreen.tsx
+++ b/frontend/src/components/ConfigScreen.tsx
@@ -834,6 +834,122 @@ export function ConfigScreen({ onBack }: { onBack: () => void }) {
                                             )}
                                         </div>
 
+                                        {/* Guest Permissions & Visibility */}
+                                        <div className="pt-6 border-t space-y-4">
+                                            <div className="space-y-1">
+                                                <Label className="text-sm font-semibold">Guest Permissions & Visibility</Label>
+                                                <p className="text-xs text-muted-foreground">
+                                                    Control what guests can do and how the event appears in calendars.
+                                                </p>
+                                            </div>
+
+                                            {/* Guest Permissions */}
+                                            <div className="space-y-3 pl-2">
+                                                <div className="flex items-start gap-4">
+                                                    <Switch
+                                                        id={`guestsCanModify-${index}`}
+                                                        checked={et.guestsCanModify ?? false}
+                                                        onCheckedChange={(checked) => updateEventType(index, { guestsCanModify: checked })}
+                                                        className="mt-1"
+                                                    />
+                                                    <div className="space-y-1">
+                                                        <Label htmlFor={`guestsCanModify-${index}`} className="text-sm font-normal cursor-pointer">
+                                                            Allow guests to modify event
+                                                        </Label>
+                                                        <span className="block text-[10px] text-muted-foreground">
+                                                            Guests can change the event time, location, and other details
+                                                        </span>
+                                                    </div>
+                                                </div>
+
+                                                <div className="flex items-start gap-4">
+                                                    <Switch
+                                                        id={`guestsCanInviteOthers-${index}`}
+                                                        checked={et.guestsCanInviteOthers ?? false}
+                                                        onCheckedChange={(checked) => updateEventType(index, { guestsCanInviteOthers: checked })}
+                                                        className="mt-1"
+                                                    />
+                                                    <div className="space-y-1">
+                                                        <Label htmlFor={`guestsCanInviteOthers-${index}`} className="text-sm font-normal cursor-pointer">
+                                                            Allow guests to invite others
+                                                        </Label>
+                                                        <span className="block text-[10px] text-muted-foreground">
+                                                            Guests can add additional attendees to the event
+                                                        </span>
+                                                    </div>
+                                                </div>
+
+                                                <div className="flex items-start gap-4">
+                                                    <Switch
+                                                        id={`guestsCanSeeOtherGuests-${index}`}
+                                                        checked={et.guestsCanSeeOtherGuests ?? true}
+                                                        onCheckedChange={(checked) => updateEventType(index, { guestsCanSeeOtherGuests: checked })}
+                                                        className="mt-1"
+                                                    />
+                                                    <div className="space-y-1">
+                                                        <Label htmlFor={`guestsCanSeeOtherGuests-${index}`} className="text-sm font-normal cursor-pointer">
+                                                            Allow guests to see other guests
+                                                        </Label>
+                                                        <span className="block text-[10px] text-muted-foreground">
+                                                            Guests can view the list of all attendees
+                                                        </span>
+                                                    </div>
+                                                </div>
+                                            </div>
+
+                                            {/* Visibility Setting */}
+                                            <div className="space-y-2">
+                                                <div className="space-y-1">
+                                                    <Label className="text-sm font-medium">Calendar Visibility</Label>
+                                                    <p className="text-xs text-muted-foreground">
+                                                        Control how the event appears in Google Calendar
+                                                    </p>
+                                                </div>
+                                                <DropdownMenu>
+                                                    <DropdownMenuTrigger asChild>
+                                                        <Button variant="outline" className="w-full justify-between font-normal h-auto min-h-10">
+                                                            <div className="flex flex-col items-start gap-0.5 text-left py-1">
+                                                                <span className="font-medium">
+                                                                    {et.visibility === 'public' ? 'Public' : et.visibility === 'private' ? 'Private' : 'Default'}
+                                                                </span>
+                                                                <span className="text-[10px] text-muted-foreground font-normal">
+                                                                    {et.visibility === 'public'
+                                                                        ? 'Event details are publicly visible'
+                                                                        : et.visibility === 'private'
+                                                                        ? 'Only shows as "Busy" without details'
+                                                                        : 'Uses calendar default visibility'}
+                                                                </span>
+                                                            </div>
+                                                            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                        </Button>
+                                                    </DropdownMenuTrigger>
+                                                    <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
+                                                        <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'default' })}>
+                                                            <div className="flex flex-col gap-1">
+                                                                <span>Default</span>
+                                                                <span className="text-xs text-muted-foreground">Uses calendar's default visibility setting</span>
+                                                            </div>
+                                                            {(!et.visibility || et.visibility === 'default') && <Check className="ml-auto h-4 w-4" />}
+                                                        </DropdownMenuItem>
+                                                        <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'public' })}>
+                                                            <div className="flex flex-col gap-1">
+                                                                <span>Public</span>
+                                                                <span className="text-xs text-muted-foreground">Event details visible to everyone</span>
+                                                            </div>
+                                                            {et.visibility === 'public' && <Check className="ml-auto h-4 w-4" />}
+                                                        </DropdownMenuItem>
+                                                        <DropdownMenuItem onClick={() => updateEventType(index, { visibility: 'private' })}>
+                                                            <div className="flex flex-col gap-1">
+                                                                <span>Private</span>
+                                                                <span className="text-xs text-muted-foreground">Shows as "Busy" without event details</span>
+                                                            </div>
+                                                            {et.visibility === 'private' && <Check className="ml-auto h-4 w-4" />}
+                                                        </DropdownMenuItem>
+                                                    </DropdownMenuContent>
+                                                </DropdownMenu>
+                                            </div>
+                                        </div>
+
                                     </div>
                                 )}
                             </Card>

--- a/frontend/src/components/ConfigScreen.tsx
+++ b/frontend/src/components/ConfigScreen.tsx
@@ -659,19 +659,10 @@ export function ConfigScreen({ onBack }: { onBack: () => void }) {
                                         </div>
                                         <DropdownMenu>
                                             <DropdownMenuTrigger asChild>
-                                                <Button variant="outline" className="w-full justify-between font-normal h-auto min-h-10">
-                                                    <div className="flex flex-col items-start gap-0.5 text-left py-1">
-                                                        <span className="font-medium">
-                                                            {et.visibility === 'public' ? 'Public' : et.visibility === 'private' ? 'Private' : 'Default'}
-                                                        </span>
-                                                        <span className="text-[10px] text-muted-foreground font-normal">
-                                                            {et.visibility === 'public'
-                                                                ? 'Event details are publicly visible'
-                                                                : et.visibility === 'private'
-                                                                ? 'Only shows as "Busy" without details'
-                                                                : 'Uses calendar default visibility'}
-                                                        </span>
-                                                    </div>
+                                                <Button variant="outline" className="w-full justify-between font-normal">
+                                                    <span className="truncate">
+                                                        {et.visibility === 'public' ? 'Public' : et.visibility === 'private' ? 'Private' : 'Default'}
+                                                    </span>
                                                     <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                                                 </Button>
                                             </DropdownMenuTrigger>

--- a/frontend/src/components/ConfigScreen.tsx
+++ b/frontend/src/components/ConfigScreen.tsx
@@ -203,6 +203,16 @@ export function ConfigScreen({ onBack }: { onBack: () => void }) {
                 alert("All event types must have a slug/id.");
                 return;
             }
+            if (et.maxBookings !== undefined) {
+                if (!Number.isInteger(et.maxBookings) || et.maxBookings < 1) {
+                    alert(`Max bookings for ${et.name} must be a positive whole number.`);
+                    return;
+                }
+                if (!['day', 'week', 'month'].includes(et.maxBookingsPeriod ?? '')) {
+                    alert(`Please select a period (day, week, or month) for the ${et.name} booking limit.`);
+                    return;
+                }
+            }
         }
 
         setSaving(true);
@@ -796,6 +806,60 @@ export function ConfigScreen({ onBack }: { onBack: () => void }) {
                                                             >
                                                                 {day.label}
                                                             </DropdownMenuCheckboxItem>
+                                                        ))}
+                                                    </DropdownMenuContent>
+                                                </DropdownMenu>
+                                            </div>
+                                        </div>
+
+                                        {/* Max Bookings Limit */}
+                                        <div className="space-y-2">
+                                            <div className="space-y-1">
+                                                <div className="flex justify-between items-center">
+                                                    <Label className="text-sm font-medium">Max Bookings</Label>
+                                                    {et.maxBookings && (
+                                                        <Button variant="link" size="sm" className="h-auto p-0 text-destructive" onClick={() => updateEventType(index, { maxBookings: undefined, maxBookingsPeriod: undefined })}>
+                                                            Remove Limit
+                                                        </Button>
+                                                    )}
+                                                </div>
+                                                <p className="text-xs text-muted-foreground">
+                                                    Cap how many times this event type can be booked per period.
+                                                </p>
+                                            </div>
+                                            <div className="flex items-center gap-3">
+                                                <Input
+                                                    type="number"
+                                                    min={1}
+                                                    className="w-28"
+                                                    placeholder="No limit"
+                                                    value={et.maxBookings || ""}
+                                                    onChange={(e) => {
+                                                        const val = parseInt(e.target.value) || undefined;
+                                                        updateEventType(index, {
+                                                            maxBookings: val,
+                                                            // Default the period to "week" when a limit is first entered.
+                                                            maxBookingsPeriod: val ? (et.maxBookingsPeriod ?? 'week') : undefined,
+                                                        });
+                                                    }}
+                                                />
+                                                <span className="text-muted-foreground text-xs">per</span>
+                                                <DropdownMenu>
+                                                    <DropdownMenuTrigger asChild disabled={!et.maxBookings}>
+                                                        <Button variant="outline" className="justify-between font-normal min-w-[110px]" disabled={!et.maxBookings}>
+                                                            <span className="capitalize">{et.maxBookingsPeriod ?? 'week'}</span>
+                                                            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                        </Button>
+                                                    </DropdownMenuTrigger>
+                                                    <DropdownMenuContent>
+                                                        {(['day', 'week', 'month'] as const).map((p) => (
+                                                            <DropdownMenuItem
+                                                                key={p}
+                                                                className="capitalize"
+                                                                onClick={() => updateEventType(index, { maxBookingsPeriod: p })}
+                                                            >
+                                                                {p}
+                                                            </DropdownMenuItem>
                                                         ))}
                                                     </DropdownMenuContent>
                                                 </DropdownMenu>

--- a/frontend/src/components/ConfigScreen.tsx
+++ b/frontend/src/components/ConfigScreen.tsx
@@ -208,8 +208,8 @@ export function ConfigScreen({ onBack }: { onBack: () => void }) {
                     alert(`Max bookings for ${et.name} must be a positive whole number.`);
                     return;
                 }
-                if (!['day', 'week', 'month'].includes(et.maxBookingsPeriod ?? '')) {
-                    alert(`Please select a period (day, week, or month) for the ${et.name} booking limit.`);
+                if (!['day', 'week', 'month', 'quarter', 'year'].includes(et.maxBookingsPeriod ?? '')) {
+                    alert(`Please select a period (day, week, month, quarter, or year) for the ${et.name} booking limit.`);
                     return;
                 }
             }
@@ -852,7 +852,7 @@ export function ConfigScreen({ onBack }: { onBack: () => void }) {
                                                         </Button>
                                                     </DropdownMenuTrigger>
                                                     <DropdownMenuContent>
-                                                        {(['day', 'week', 'month'] as const).map((p) => (
+                                                        {(['day', 'week', 'month', 'quarter', 'year'] as const).map((p) => (
                                                             <DropdownMenuItem
                                                                 key={p}
                                                                 className="capitalize"

--- a/frontend/src/models/EventType.ts
+++ b/frontend/src/models/EventType.ts
@@ -9,6 +9,12 @@ export interface EventType {
     DAYS_IN_ADVANCE?: number;
     CALENDARS?: string[];
     schedulingStrategy?: 'collective' | 'round_robin';
+    // Guest permissions
+    guestsCanModify?: boolean;
+    guestsCanInviteOthers?: boolean;
+    guestsCanSeeOtherGuests?: boolean;
+    // Meeting visibility
+    visibility?: 'default' | 'public' | 'private';
 }
 
 export interface Config {

--- a/frontend/src/models/EventType.ts
+++ b/frontend/src/models/EventType.ts
@@ -12,7 +12,7 @@ export interface EventType {
     // Max bookings limit (undefined/0 = no limit). Active only when maxBookings > 0
     // and maxBookingsPeriod is set. Applies to the whole event type (aggregate).
     maxBookings?: number;
-    maxBookingsPeriod?: 'day' | 'week' | 'month';
+    maxBookingsPeriod?: 'day' | 'week' | 'month' | 'quarter' | 'year';
     // Guest permissions
     guestsCanModify?: boolean;
     guestsCanInviteOthers?: boolean;

--- a/frontend/src/models/EventType.ts
+++ b/frontend/src/models/EventType.ts
@@ -9,6 +9,10 @@ export interface EventType {
     DAYS_IN_ADVANCE?: number;
     CALENDARS?: string[];
     schedulingStrategy?: 'collective' | 'round_robin';
+    // Max bookings limit (undefined/0 = no limit). Active only when maxBookings > 0
+    // and maxBookingsPeriod is set. Applies to the whole event type (aggregate).
+    maxBookings?: number;
+    maxBookingsPeriod?: 'day' | 'week' | 'month';
     // Guest permissions
     guestsCanModify?: boolean;
     guestsCanInviteOthers?: boolean;


### PR DESCRIPTION
**Summary**
Adds a per-event-type booking cap, limiting how many times an event type can be booked within a rolling period. Default is no limit.

Stacked on claude/implement-feature-mklmrqugjeutx7cm-sfl16 (https://github.com/rbbydotdev/someday/pull/17); merge that first.

**Features**
📅 **Booking Limit (Number + Period Picker)**
- **Number** - Max bookings allowed (blank = no limit)
- **Period** - Day, Week, Month, Quarter, or Year (calendar-based, in your time zone)

🚫 **Two-Layer Enforcement**
- **Availability** - Maxed-out periods are hidden from the booking page
- **Booking** - Server-side check rejects any attempt to exceed the cap (lock-guarded against races)

🏷️ **Whole-Event-Type Scope**
- Counts aggregate across all monitored calendars, including Round-Robin hosts
- Only bookings made after this ships are counted
